### PR TITLE
Gateway gRPC API for leaderboard and its dummy implementation.

### DIFF
--- a/gateway/src/main/java/xyz/breakit/gateway/Gateway.java
+++ b/gateway/src/main/java/xyz/breakit/gateway/Gateway.java
@@ -33,6 +33,7 @@ public class Gateway {
 
         Server server = ServerBuilder.forPort(8080)
                 .addService(new FixtureService(geeseClient, cloudsClient))
+                .addService(new LeaderboardService())
                 .build();
         server.start();
 

--- a/gateway/src/main/java/xyz/breakit/gateway/GatewayClient.java
+++ b/gateway/src/main/java/xyz/breakit/gateway/GatewayClient.java
@@ -1,8 +1,9 @@
 package xyz.breakit.gateway;
 
-import io.grpc.ManagedChannel;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
 import xyz.breakit.gateway.FixtureServiceGrpc.FixtureServiceBlockingStub;
+import xyz.breakit.gateway.LeaderboardServiceGrpc.LeaderboardServiceBlockingStub;
 
 /**
  * Client to call gateway service.
@@ -11,17 +12,29 @@ public class GatewayClient {
 
     public static void main(String[] args) {
         String host = "35.230.13.179";
-        ManagedChannel channel = NettyChannelBuilder.forAddress(host, 8080)
-                .usePlaintext().build();
+        Channel channel = ManagedChannelBuilder.forAddress(host, 8080).usePlaintext().build();
+        callFixtureService(channel);
+        callLeaderboardService(channel);
+    }
+
+    private static void callFixtureService(Channel channel) {
         FixtureServiceBlockingStub client = FixtureServiceGrpc.newBlockingStub(channel);
 
-        GetFixtureRequest request = GetFixtureRequest.newBuilder()
+        GetFixtureRequest fixtureRequest = GetFixtureRequest.newBuilder()
                 .setLinesCount(10)
                 .setLineWidth(10)
                 .build();
 
-        FixtureResponse response = client.getFixture(request);
-        System.out.println("Response: " + response);
+        FixtureResponse fixture = client.getFixture(fixtureRequest);
+        System.out.println("FixtureResponse: " + fixture);
+    }
+
+    private static void callLeaderboardService(Channel channel) {
+        LeaderboardServiceBlockingStub client = LeaderboardServiceGrpc.newBlockingStub(channel);
+
+        TopScoresRequest topScoresRequest = TopScoresRequest.newBuilder().setSize(3).build();
+        TopScoresResponse topScores = client.getTopScores(topScoresRequest);
+        System.out.println("TopScoresResponse: " + topScores);
     }
 
 }

--- a/gateway/src/main/java/xyz/breakit/gateway/LeaderboardService.java
+++ b/gateway/src/main/java/xyz/breakit/gateway/LeaderboardService.java
@@ -1,0 +1,35 @@
+package xyz.breakit.gateway;
+
+import io.grpc.stub.StreamObserver;
+import xyz.breakit.gateway.LeaderboardServiceGrpc.LeaderboardServiceImplBase;
+
+/**
+ * Implementation of gateway leaderboard service.
+ * Currently returns predefined responses, but should make
+ * remote calls to leaderboard service instead.
+ */
+public class LeaderboardService extends LeaderboardServiceImplBase {
+
+    @Override
+    public void getTopScores(TopScoresRequest request,
+                             StreamObserver<TopScoresResponse> responseObserver) {
+
+        // Mykyta: Make call to leaderboard service here and convert its response to TopScoresResponse
+        TopScoresResponse response = TopScoresResponse.newBuilder()
+                .addTopScores(PlayerScore.newBuilder().setPlayerId("Petro").setScore(100500).build())
+                .addTopScores(PlayerScore.newBuilder().setPlayerId("Vasyl").setScore(321).build())
+                .addTopScores(PlayerScore.newBuilder().setPlayerId("Hanna").setScore(42).build())
+                .build();
+
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void updateScore(UpdateScoreRequest request,
+                            StreamObserver<UpdateScoreResponse> responseObserver) {
+        // Mykyta: Make call to leaderboard service here
+        responseObserver.onNext(UpdateScoreResponse.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+}

--- a/grpc-api/src/main/proto/gateway.proto
+++ b/grpc-api/src/main/proto/gateway.proto
@@ -19,6 +19,20 @@ service FixtureService {
 }
 
 /*
+ * Leaderbaord, service to keep track of top players.
+ */
+service LeaderboardService {
+    /*
+     * Returns current top scores (up to a requested number).
+     */
+    rpc GetTopScores (TopScoresRequest) returns (TopScoresResponse);
+    /*
+     * Updates single player's score.
+     */
+    rpc UpdateScore (UpdateScoreRequest) returns (UpdateScoreResponse);
+}
+
+/*
  * Request to recieve next lines.
  */
 message GetFixtureRequest {
@@ -58,4 +72,55 @@ message FixtureLine {
      * and fourth column of the line.
      */
     repeated int32 cloud_positions = 2;
+}
+
+/*
+ * Contains single player's score.
+ */
+message PlayerScore {
+    /*
+     * Player's unique id.
+     */
+    string player_id = 1;
+    /*
+     * Current player's score.
+     */
+    int32 score = 2;
+}
+
+/*
+ * Request to request current top scores.
+ */
+message TopScoresRequest {
+    /*
+     * Max number of scores to return.
+     */
+    int32 size = 1;
+}
+
+/*
+ * Contains current top scores.
+ */
+message TopScoresResponse {
+    /*
+     * List of top scores.
+     * Position in this list represents player'sc position in the leaderboard.
+     */
+    repeated PlayerScore top_scores = 1;
+}
+
+/*
+ * Request to update player's score.
+ */
+message UpdateScoreRequest {
+    /*
+     * Contains player's unique id and new score.
+     */
+    PlayerScore player_score = 1;
+}
+
+/*
+ * Response message, currently empty.
+ */
+message UpdateScoreResponse {
 }


### PR DESCRIPTION
Mykyta, I made comments in LeaderboardService where you need to call leaderboard service.

To test using gRPC client execute in service/gateway:
./gradlew runClient