### PR TITLE
Use default connection timeout in Leaderboard client

### DIFF
--- a/gateway/src/main/java/xyz/breakit/gateway/clients/leaderboard/LeaderboardAdminClient.java
+++ b/gateway/src/main/java/xyz/breakit/gateway/clients/leaderboard/LeaderboardAdminClient.java
@@ -1,54 +1,70 @@
 package xyz.breakit.gateway.clients.leaderboard;
 
 import com.google.protobuf.util.Durations;
-import com.google.rpc.Status;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.sleuth.instrument.async.TraceableScheduledExecutorService;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import xyz.breakit.admin.*;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 @Service
 public class LeaderboardAdminClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(LeaderboardAdminClient.class);
-    public static final String EMPTY_BODY = "";
+
+    private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+    private final static RetryPolicy NO_RETRY_POLICY = new RetryPolicy()
+            .retryOn(Throwable.class)
+            .withMaxRetries(0);
 
     private final String leaderboardUrl;
     private final WebClient httpClient;
+    private final BeanFactory beanFactory;
 
 
     @Autowired
     public LeaderboardAdminClient(
             @Value("${rest.leaderboard.host}") String leaderboardHost,
             @Value("${rest.leaderboard.port}") int leaderboardPort,
-            WebClient webClientTemplate
-    ) {
+            WebClient webClientTemplate,
+            BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
         this.leaderboardUrl = "http://" + leaderboardHost + ":" + leaderboardPort;
         LOG.info("LB URL: {}", leaderboardUrl);
 
-        httpClient = webClientTemplate.mutate().baseUrl(leaderboardUrl).build();
+        httpClient = webClientTemplate.mutate()
+                .baseUrl(leaderboardUrl).build();
     }
 
     public CompletableFuture<HealthCheckResponse> health() {
-        return httpClient
-                .get()
-                .uri("/admin/health")
-                .retrieve()
-                .bodyToMono(Health.class)
-                .timeout(Duration.ofMillis(1000))
-                .map(this::toServiceHealthCheckStatus)
-                .map(status ->
-                        HealthCheckResponse.newBuilder().addServiceHealthStatus(status).build())
-                .toFuture();
+        return Failsafe
+                .with(NO_RETRY_POLICY)
+                .with(new TraceableScheduledExecutorService(beanFactory, EXECUTOR))
+                .future(() ->
+                        httpClient
+                                .get()
+                                .uri("/admin/health")
+                                .retrieve()
+                                .bodyToMono(Health.class)
+                                .timeout(Duration.ofMillis(1000))
+                                .map(this::toServiceHealthCheckStatus)
+                                .map(status ->
+                                        HealthCheckResponse
+                                                .newBuilder()
+                                                .addServiceHealthStatus(status
+                                                ).build())
+                                .toFuture());
     }
 
     private ServiceHealthCheckStatus toServiceHealthCheckStatus(Health health) {
@@ -67,68 +83,56 @@ public class LeaderboardAdminClient {
                 : FailureCodeSpec.getDefaultInstance();
 
         return ServiceHealthCheckStatus.newBuilder()
-                    .setServiceName("leaderboard")
-                    .setCodeFailure(failureCodeSpec)
-                    .setAddedLatency(addedLatencySpec)
-                    .build();
+                .setServiceName("leaderboard")
+                .setCodeFailure(failureCodeSpec)
+                .setAddedLatency(addedLatencySpec)
+                .build();
 
     }
 
-    public CompletableFuture<Void> enableLimit(int limit) {
-        return httpClient
-                .post()
-                .uri("/admin/rateLimit/" + limit)
-                .contentType(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(String.class)
-                .timeout(Duration.ofMillis(1000))
-                .map(s -> (Void) null)
-                .toFuture();
+    public CompletableFuture<String> breakService() {
+        return Failsafe
+                .with(NO_RETRY_POLICY)
+                .with(new TraceableScheduledExecutorService(beanFactory, EXECUTOR))
+                .future(() ->
+                        httpClient
+                                .post()
+                                .uri("/admin/break")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .retrieve()
+                                .bodyToMono(String.class)
+                                .timeout(Duration.ofMillis(1000))
+                                .toFuture());
     }
 
-    public CompletableFuture<Void> disableLimit() {
-        return httpClient
-                .post()
-                .uri("/admin/disableRateLimit")
-                .contentType(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(s -> (Void) null)
-                .toFuture();
+    public CompletableFuture<String> unbreakService() {
+        return Failsafe
+                .with(NO_RETRY_POLICY)
+                .with(new TraceableScheduledExecutorService(beanFactory, EXECUTOR))
+                .future(() ->
+                        httpClient
+                                .post()
+                                .uri("/admin/unbreak")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .retrieve()
+                                .bodyToMono(String.class)
+                                .timeout(Duration.ofMillis(1000))
+                                .toFuture());
     }
 
-
-    public CompletableFuture<Void> breakService() {
-        return httpClient
-                .post()
-                .uri("/admin/break")
-                .contentType(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(s -> (Void) null)
-                .toFuture();
-    }
-
-    public CompletableFuture<Void> unbreakService() {
-        return httpClient
-                .post()
-                .uri("/admin/unbreak")
-                .contentType(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(s -> (Void) null)
-                .toFuture();
-    }
-
-    public CompletableFuture<Void> clear() {
-        return httpClient
-                .post()
-                .uri("/admin/clear")
-                .contentType(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(s -> (Void) null)
-                .toFuture();
+    public CompletableFuture<String> clear() {
+        return Failsafe
+                .with(NO_RETRY_POLICY)
+                .with(new TraceableScheduledExecutorService(beanFactory, EXECUTOR))
+                .future(() ->
+                        httpClient
+                                .post()
+                                .uri("/admin/clear")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .retrieve()
+                                .bodyToMono(String.class)
+                                .timeout(Duration.ofMillis(1000))
+                                .toFuture());
     }
 
 }

--- a/gateway/src/main/java/xyz/breakit/gateway/controller/AdminController.java
+++ b/gateway/src/main/java/xyz/breakit/gateway/controller/AdminController.java
@@ -52,8 +52,8 @@ public class AdminController {
         CompletableFuture<Object> cloudsResult = injectLatencyInto("clouds", 0.0, 0, false);
 
         try {
-            lbAdminClient.unbreakService().get(1, TimeUnit.SECONDS);
-            lbAdminClient.clear().get(1, TimeUnit.SECONDS);
+            lbAdminClient.unbreakService().get();
+            lbAdminClient.clear().get();
             lbClient.disableRetries();
 
             CompletableFuture.allOf(geeseResult, cloudsResult).get(1, TimeUnit.SECONDS);
@@ -72,7 +72,7 @@ public class AdminController {
         CompletableFuture<Object> cloudsResult = injectLatencyInto("clouds", 1, 700, false);
 
         try {
-            lbAdminClient.breakService().get(1, TimeUnit.SECONDS);
+            lbAdminClient.breakService().get();
             lbClient.disableRetries();
 
             CompletableFuture.allOf(geeseResult, cloudsResult)
@@ -92,7 +92,7 @@ public class AdminController {
         CompletableFuture<Object> cloudsResult = injectLatencyInto("clouds", 1, 700, false);
 
         try {
-            lbAdminClient.breakService().get(1, TimeUnit.SECONDS);
+            lbAdminClient.breakService().get();
             lbClient.disableRetries();
 
             CompletableFuture.allOf(geeseResult, cloudsResult)
@@ -112,7 +112,7 @@ public class AdminController {
         CompletableFuture<Object> cloudsResult = injectLatencyInto("clouds", 1, 700, false);
 
         try {
-            lbAdminClient.breakService().get(1, TimeUnit.SECONDS);
+            lbAdminClient.breakService().get();
             lbClient.enableRetriesWithNoBackoff();
 
             CompletableFuture.allOf(geeseResult, cloudsResult).get(1, TimeUnit.SECONDS);
@@ -130,9 +130,8 @@ public class AdminController {
         CompletableFuture<Object> cloudsResult = injectLatencyInto("clouds", 0.0, 0, false);
 
         try {
-            lbAdminClient.unbreakService().get(1, TimeUnit.SECONDS);
+            lbAdminClient.unbreakService().get();
             lbClient.disableRetries();
-
 
             CompletableFuture.allOf(geeseResult, cloudsResult).get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
@@ -149,7 +148,7 @@ public class AdminController {
         CompletableFuture<Object> cloudsResult = injectLatencyInto("clouds", 0.0, 0, false);
 
         try {
-            lbAdminClient.unbreakService().get(1, TimeUnit.SECONDS);
+            lbAdminClient.unbreakService().get();
             lbClient.disableRetries();
 
 

--- a/leaderboard/src/main/java/xyz/breakit/leaderboard/rest/AdminController.java
+++ b/leaderboard/src/main/java/xyz/breakit/leaderboard/rest/AdminController.java
@@ -30,29 +30,33 @@ public class AdminController {
     }
 
     @PostMapping(value = "/clear")
-    public void clear() {
+    public String clear() {
         leaderboardService.clear();
+        return "OK";
     }
 
     @PostMapping(value = "/break")
-    public void breakService() {
+    public String breakService() {
         leaderboardService.breakService();
+        return "OK";
     }
 
     @PostMapping(value = "/unbreak")
-    public void unbreak() {
+    public String unbreak() {
         leaderboardService.unbreak();
+        return "OK";
     }
 
     @PostMapping(value = "/rateLimit/{n}")
-    public void rateLimit(@PathVariable("n") int n) {
+    public String rateLimit(@PathVariable("n") int n) {
         limiterFilter.enable(n);
+        return "OK";
     }
 
     @PostMapping(value = "/disableRateLimit")
-    public void disableRateLimit() {
+    public String disableRateLimit() {
         limiterFilter.disable();
+        return "OK";
     }
-
 
 }


### PR DESCRIPTION
Use separate executor for leaderboard admin client
Return a String in AdminController in leaderboard so we can get a meangful signal.
Rely on Mono timeouts, remove duplicate Future timeouts